### PR TITLE
Fix readArray was not declared in this scope.

### DIFF
--- a/src/eigen/ludecomposition.h
+++ b/src/eigen/ludecomposition.h
@@ -85,7 +85,7 @@ class LUDecomposition
 public:
 
     /** Performs the LU Decomposition of mat. Use this constructor. */
-    LUDecomposition( const Matrix<T, Size> & mat ) { perform( mat ); }
+    LUDecomposition( const Matrix<T, Size> & mat ) { this->perform( mat ); }
 
 protected:
     /** Default constructor. Does nothing. \internal

--- a/src/eigen/matrix.h
+++ b/src/eigen/matrix.h
@@ -170,7 +170,7 @@ public:
       */
     Matrix( const Matrix & other )
     {
-        readArray( other.array() );
+        this->readArray( other.array() );
     }
 
     /**

--- a/src/eigen/vector.h
+++ b/src/eigen/vector.h
@@ -149,7 +149,7 @@ public:
       */
     Vector( const T *array )
     {
-        readArray( array );
+        this->readArray( array );
     }
 
     /**

--- a/src/eigen/vector.h
+++ b/src/eigen/vector.h
@@ -141,7 +141,7 @@ public:
       */
     Vector( const Vector &v )
     {
-        readArray( v.array() );
+        this->readArray( v.array() );
     }
 
     /**


### PR DESCRIPTION
This fixes a bug in eigen that prevents Silver Tree from compiling without `-fpermissive`.

The error from `make` regarding vector.h:
```
In file included from tile.hpp:21:0,
                 from gamemap.hpp:20,
                 from world.hpp:30,
                 from titlescreen.cpp:9:
eigen/vector.h: In instantiation of ‘Eigen::Vector<T, Size>::Vector(const Eigen::Vector<T, Size>&) [with T = float; int Size = 3]’:
animation.hpp:72:64:   required from ‘ValueType graphics::function_animation<ValueType, Function>::operator()(float) const [with ValueType = Eigen::Vector<float, 3>; Function = graphics::quadratic_function<Eigen::Vector<float, 3> >]’
titlescreen.cpp:144:1:   required from here
eigen/vector.h:144:18: error: ‘readArray’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
         readArray( v.array() );
         ~~~~~~~~~^~~~~~~~~~~~~
eigen/vector.h:144:18: note: declarations in dependent base ‘Eigen::VectorBase<float, Eigen::Vector<float, 3> >’ are not found by unqualified lookup
eigen/vector.h:144:18: note: use ‘this->readArray’ instead
```

The error from `make` regarding matrix.h:
```
In file included from eigen/projective.h:33:0,
                 from model.hpp:21,
                 from parse3ds.cpp:16:
eigen/matrix.h: In instantiation of 'Eigen::Matrix<T, Size>::Matrix(const Eigen::Matrix<T, Size>&) [with T = float; int Size = 4]':
eigen/projective.h:215:59:   required from 'Eigen::MatrixP<T, Size>::MatrixP(const Eigen::MatrixP<T, Size>&) [with T = float; int Size = 3]'
model.hpp:46:9:   required from 'void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = graphics::model::face; _Args = {const graphics::model::face&}; _Tp = graphics::model::face]'
/usr/include/c++/7/bits/alloc_traits.h:475:4:   required from 'static void std::allocator_traits<std::allocator<_CharT> >::construct(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, _Up*, _Args&& ...) [with _Up = graphics::model::face; _Args = {const graphics::model::face&}; _Tp = graphics::model::face; std::allocator_traits<std::allocator<_CharT> >::allocator_type = std::allocator<graphics::model::face>]'
/usr/include/c++/7/bits/stl_vector.h:943:30:   required from 'void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = graphics::model::face; _Alloc = std::allocator<graphics::model::face>; std::vector<_Tp, _Alloc>::value_type = graphics::model::face]'
parse3ds.cpp:172:20:   required from here
eigen/matrix.h:173:18: error: 'readArray' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
         readArray( other.array() );
         ~~~~~~~~~^~~~~~~~~~~~~~~~~
eigen/matrix.h:173:18: note: declarations in dependent base 'Eigen::MatrixBase<float, Eigen::Matrix<float, 4>, Eigen::Vector<float, 4>, Eigen::LUDecomposition<float, 4> >' are not found by unqualified lookup
eigen/matrix.h:173:18: note: use 'this->readArray' instead
```

The error from make regarding ludecomposition.h:
```
In file included from eigen/matrix.h:33:0,
                 from eigen/projective.h:33,
                 from model.hpp:21,
                 from model.cpp:15:
eigen/ludecomposition.h: In instantiation of ‘Eigen::LUDecomposition<T, Size>::LUDecomposition(const Eigen::Matrix<T, Size>&) [with T = float; int Size = 3]’:
eigen/matrixbase.h:1789:9:   required from ‘void Eigen::MatrixBase<T, Derived, VectorType, LUDecompositionType>::computeInverse(Derived*) const [with T = float; Derived = Eigen::Matrix<float, 3>; VectorType = Eigen::Vector<float, 3>; LUDecompositionType = Eigen::LUDecomposition<float, 3>]’
eigen/matrixbase.h:1094:23:   required from ‘Derived Eigen::MatrixBase<T, Derived, VectorType, LUDecompositionType>::inverse() const [with T = float; Derived = Eigen::Matrix<float, 3>; VectorType = Eigen::Vector<float, 3>; LUDecompositionType = Eigen::LUDecomposition<float, 3>]’
model.cpp:224:101:   required from here
eigen/ludecomposition.h:88:61: error: ‘perform’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
     LUDecomposition( const Matrix<T, Size> & mat ) { perform( mat ); }
                                                      ~~~~~~~^~~~~~~
eigen/ludecomposition.h:88:61: note: declarations in dependent base ‘Eigen::LUDecompositionBase<float, Eigen::Matrix<float, 3>, Eigen::Vector<float, 3>, Eigen::Vector<int, 3> >’ are not found by unqualified lookup
eigen/ludecomposition.h:88:61: note: use ‘this->perform’ instead
```